### PR TITLE
Add minify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Information on the plugins can be found [here](https://www.npmjs.com/package/svg
 
 **Thanks to [LaurentTreguier](https://github.com/LaurentTreguier) for sharing SVG formatting features**
 
+### Minify SVG with SVGO
+
+Open the **Command Palette** (`⇧⌘P` on Mac and `Ctrl+Shift+P` on Win/Linux) and run `Minify SVG`. This will reduce the filesize significantly by removing all unnecessary code from the image.
+
 ## Known Issues
 
 Configuration option functionality is not yet implemented.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
                 "title": "Move Cursor"
             },
             {
+                "command": "_svg.minifySvg",
+                "title": "Minify SVG"
+            },
+            {
                 "command": "_svg.showSvg",
                 "title": "%svg.showSvg.title%",
                 "icon": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import {SvgHoverProvider} from './features/svgHoverProvider';
 import {SvgRenameProvider} from './features/svgRenameProvider';
 import {SvgDefinitionProvider} from './features/svgDefinitionProvider';
 import {SvgFormattingProvider} from './features/svgFormattingProvider';
+import {svgMinify} from './features/svgMinify';
 
 import {SvgPreviwerContentProvider} from './previewer'
 
@@ -51,10 +52,11 @@ export function activate(context: vscode.ExtensionContext) {
     let d5 = vscode.languages.registerDocumentSymbolProvider(SVG_MODE, new SvgSymbolProvider());
     let d6 = vscode.languages.registerHoverProvider(SVG_MODE, new SvgHoverProvider());
     let d7 = vscode.languages.registerRenameProvider(SVG_MODE, new SvgRenameProvider());
-    let d8 = vscode.languages.registerDefinitionProvider(SVG_MODE, new SvgDefinitionProvider());   
-    let d9 = vscode.languages.registerDocumentFormattingEditProvider(SVG_MODE, new SvgFormattingProvider());   
+    let d8 = vscode.languages.registerDefinitionProvider(SVG_MODE, new SvgDefinitionProvider());
+    let d9 = vscode.languages.registerDocumentFormattingEditProvider(SVG_MODE, new SvgFormattingProvider());
+    let d10 = vscode.commands.registerTextEditorCommand('_svg.minifySvg', svgMinify);
 
-    context.subscriptions.push(d1, d2, d3, d4, d5, d6, d7, d8);
+    context.subscriptions.push(d1, d2, d3, d4, d5, d6, d7, d8, d10);
 }
 
 // this method is called when your extension is deactivated

--- a/src/features/svgMinify.ts
+++ b/src/features/svgMinify.ts
@@ -1,0 +1,16 @@
+import { Range, Position, TextEditor, TextEditorEdit } from 'vscode';
+import svgo = require('svgo');
+
+export function svgMinify(textEditor: TextEditor, edit: TextEditorEdit) {
+    let optimizer = new svgo({});
+    let document = textEditor.document;
+
+    return new Promise((resolve, reject) => {
+        optimizer.optimize(document.getText(), (result) => {
+            if (result.error) reject(result.error);
+            let range = new Range(new Position(0, 0), document.lineAt(document.lineCount - 1).range.end)
+            edit.replace(range, result.data);
+            resolve();
+        });
+    });
+}


### PR DESCRIPTION
Adds minify command to run SVGO with default settings. Unlike format this will create an uglified file to save space.

In my daily work I am often given SVGs created by Sketch or Illustrator. These are way to large to use in production so I have to optimize them with SVGO. This PR allows me to do this without leaving the editor.