### PR TITLE
Add the xmlns and xmlns:xlink attributes

### DIFF
--- a/src/features/svg.ts
+++ b/src/features/svg.ts
@@ -1356,7 +1356,8 @@ export function getSvgJson(): ISvgJson {
                     },
                     "baseProfile",
                     "x", "y", "width", "height", "preserveAspectRatio", "contentScriptType", "contentStyleType",
-                    "viewBox"
+                    "viewBox",
+                    "xmlns", "xmlns:xlink"
                 ]
             },
             "switch": {
@@ -2457,6 +2458,16 @@ For the <radialgradient> element, this attribute defines the radius of the large
             "xml:lang": {
                 name: "xml:lang",
                 documentation: `xml:lang is a universal attribute allowed in all XML dialects to mark up the natural human language that an element contains. It's almost identical in usage to HTML's lang, but in conforming XML 1.0 documents, it does not allow the use of a null attribute value (xml:lang="") to indicate an unknown language. Instead, use xml:lang="und".`
+            },
+            "xmlns": {
+                name: "xmlns",
+                documentation: "The SVG namespace, declared as the default namespace for this element and its children.",
+                enum: ["http://www.w3.org/2000/svg"]
+            },
+            "xmlns:xlink": {
+                name: "xmlns:xlink",
+                documentation: "The XLink namespace, attached to the `xlink` prefix.",
+                enum: ["http://www.w3.org/1999/xlink"]
             },
             "y": {
                 name: "y",


### PR DESCRIPTION
With the correct namespace URI for each as a single-option enum.

I've only added the attributes to the content model for `<svg>`, although of course the attributes are really global.
But it is normal with SVG to only declare the namespaces on the root element. If you were going to use `xmlns` anywhere else, it would probably be to set a different namespace URI on child elements of `<metadata>` or `<foreignObject>`.  But I wasn't sure how to add that option to your code!