### PR TITLE
Respect editor tab size in formatting provider

### DIFF
--- a/src/features/svgFormattingProvider.ts
+++ b/src/features/svgFormattingProvider.ts
@@ -42,6 +42,7 @@ export class SvgFormattingProvider implements DocumentFormattingEditProvider {
 
     provideDocumentFormattingEdits(document: TextDocument, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]> {
         let config = workspace.getConfiguration('svg.format.plugins');
+        const {activeTextEditor} = window;
         let plugins = this._plugins
             .map((configName) => {
                 let plugin = {};
@@ -50,7 +51,7 @@ export class SvgFormattingProvider implements DocumentFormattingEditProvider {
             }) as any[];
         let formatter = new svgo({
             plugins: plugins,
-            js2svg: { pretty: true }
+            js2svg: { pretty: true, indent: <number>activeTextEditor.options.tabSize }
         });
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Currently, the "Pretty SVG" command respects the tab size set in VS Code, but the "Format Document" command does not—it always uses 4 spaces for each level of indentation, the default for svgo. This PR makes "Format Document" use the user's preferred number of spaces, the [same way](https://github.com/lishu/vscode-svg/blob/43122d07db14e6ee3defae388d44173f1144d843/src/features/svgPretty.ts#L11) "Pretty SVG" does.

You might consider removing the "Pretty SVG" command entirely. To me, it feels redundant with the formatting provider.